### PR TITLE
Broken in Chrome and Safari

### DIFF
--- a/inc-scout2/scout2.js
+++ b/inc-scout2/scout2.js
@@ -249,7 +249,7 @@ var recursive_count = function(input, entities) {
     if (entities.length > 0) {
         var entity = entities.shift();
         for (i in input[entity]) {
-            count = count + recursive_count(input[entity][i], eval(uneval(entities)));
+            count = count + recursive_count(input[entity][i], eval(JSON.stringify(entities)));
         }
     } else {
         count = count + 1;


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/uneval breaks chrome and safari
