### PR TITLE
change readable to listable: bucket ACLs allow list, not read

### DIFF
--- a/rules/findings-s3.default.json
+++ b/rules/findings-s3.default.json
@@ -8,10 +8,10 @@
         "targets": [
             ["All users", "write", "Bucket world-writable", "danger"],
             ["All users", "write_acp", "Bucket's permissions world-writable", "danger"],
-            ["All users", "read", "Bucket world-readable", "warning"],
+            ["All users", "read", "Bucket world-listable", "warning"],
             ["Authenticated users", "write", "Bucket world-writable", "danger"],
             ["Authenticated users", "write_acp", "Bucket's permissions world-writable", "danger"],
-            ["Authenticated users", "read", "Bucket world-readable", "warning"]
+            ["Authenticated users", "read", "Bucket world-listable", "warning"]
         ],
         "questions": [
             "Report _DESCRIPTION_"


### PR DESCRIPTION
Changing the wording from 'readable' to 'listable' when the `READ` ACL is set on a S3 bucket ACL.

Taking a look at the documentation and performing several tests, I believe this is correct.

Documentation: http://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html

    Permission: When granted on a bucket
    READ: Allows grantee to list the objects in the bucket

# Testing

I created a bucket in an account, setup a profile for the AWS CLI in another account.  Added 'Authenticated Users' READ & View Permissions:

`ACP: 
<Policy: me (owner) = READ, me (owner) = WRITE, me (owner) = READ_ACP, me (owner) = WRITE_ACP, http://acs.amazonaws.com/groups/global/AuthenticatedUsers = READ, http://acs.amazonaws.com/groups/global/AuthenticatedUsers = READ_ACP>
`

## AWS CLI

    $ aws --profile some_other_account_that_doesnt_own_this_bucket s3 ls some-test-bucket
    2015-07-28 20:30:55          5 foo

    $ aws --profile some_other_account_that_doesnt_own_this_bucket s3 cp s3://some-test-bucket/foo .
    A client error (403) occurred when calling the HeadObject operation: Forbidden

## Python SDK

    >>> import boto3
    >>> s3_client = boto3.client('s3')
    >>> s3_client.download_file('some-test-bucket', 'foo', 'foo')
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      File "/opt/foo/lib/python2.7/site-packages/boto3/s3/inject.py", line 35, in download_file
        extra_args=ExtraArgs, callback=Callback)
      File "/opt/foo/lib/python2.7/site-packages/boto3/s3/transfer.py", line 614, in download_file
        object_size = self._object_size(bucket, key, extra_args)
      File "/opt/foo/lib/python2.7/site-packages/boto3/s3/transfer.py", line 680, in _object_size
        Bucket=bucket, Key=key, **extra_args)['ContentLength']
      File "/opt/foo/lib/python2.7/site-packages/botocore/client.py", line 258, in _api_call
        return self._make_api_call(operation_name, kwargs)
      File "/opt/foo/lib/python2.7/site-packages/botocore/client.py", line 315, in _make_api_call
        raise ClientError(parsed_response, operation_name)
    botocore.exceptions.ClientError: An error occurred (403) when calling the HeadObject operation: Forbidden

This is annoyingly unintuitive but I think that this wording update makes it much clearer.  It could be taken a step further and also update 'Read access' to 'List access' but I didn't immediately see where that piece of the code lives.  Happy to edit if some more guidance is provided.