### PR TITLE
Modify SG display to print a friendly name for known CIDRs

### DIFF
--- a/AWSScout2/finding_ec2.py
+++ b/AWSScout2/finding_ec2.py
@@ -39,6 +39,7 @@ class Ec2Finding(Finding):
             for port in obj['rules']['ingress']['protocols'][protocol]['ports']:
                 if 'cidrs' in obj['rules']['ingress']['protocols'][protocol]['ports'][port]:
                     for cidr in obj['rules']['ingress']['protocols'][protocol]['ports'][port]['cidrs']:
+                        cidr = cidr['CIDR']
                         if cidr == '0.0.0.0/0':
                             if method == 'blacklist' and self.portInRange(check_port, port):
                                 self.addItem(obj['id'])
@@ -65,6 +66,7 @@ class Ec2Finding(Finding):
             for port in obj['rules']['ingress']['protocols'][protocol]['ports']:
                 if 'cidrs' in obj['rules']['ingress']['protocols'][protocol]['ports'][port]:
                     for cidr in obj['rules']['ingress']['protocols'][protocol]['ports'][port]['cidrs']:
+                        cidr = cidr['CIDR']
                         authorized_cidr = netaddr.IPNetwork(cidr)
                         for ec2_cidr in self.callback_args:
                             ec2_cidr = netaddr.IPNetwork(ec2_cidr)

--- a/AWSScout2/utils_ec2.py
+++ b/AWSScout2/utils_ec2.py
@@ -390,7 +390,7 @@ def parse_security_group_rules(rules):
             protocols[ip_protocol]['ports'][port_value]['security_groups'].append(grant)
         for grant in rule['IpRanges']:
             manage_dictionary(protocols[ip_protocol]['ports'][port_value], 'cidrs', [])
-            protocols[ip_protocol]['ports'][port_value]['cidrs'].append(grant['CidrIp'])
+            protocols[ip_protocol]['ports'][port_value]['cidrs'].append({'CIDR': grant['CidrIp']})
     return protocols
 
 def get_name(local, remote, default_attribute):

--- a/AWSScout2/utils_vpc.py
+++ b/AWSScout2/utils_vpc.py
@@ -11,7 +11,7 @@ from AWSScout2.utils import *
 #
 # VPC-level analysis
 #
-def analyze_vpc_config(aws_config):
+def analyze_vpc_config(aws_config, ip_ranges, ip_ranges_name_key):
     printInfo('Analyzing VPC config...')
     # Security group usage: EC2 instances
     callback_args = {'status_path': ['State', 'Name'], 'sg_list_attribute_name': 'security_groups', 'sg_id_attribute_name': 'GroupId'}
@@ -22,6 +22,10 @@ def analyze_vpc_config(aws_config):
     # Security group usage: RDS instances
     callback_args = {'status_path': ['DBInstanceStatus'], 'sg_list_attribute_name': 'VpcSecurityGroups', 'sg_id_attribute_name': 'VpcSecurityGroupId'}
     go_to_and_do(aws_config, aws_config['services']['rds'], ['regions', 'vpcs', 'instances'], ['services', 'rds'], list_resources_in_security_group, callback_args)
+    # Add friendly name for CIDRs
+    if len(ip_ranges):
+        callback_args = {'ip_ranges': ip_ranges, 'ip_ranges_name_key': ip_ranges_name_key}
+        go_to_and_do(aws_config, aws_config['services']['ec2'], ['regions', 'vpcs', 'security_groups', 'rules', 'protocols', 'ports'], ['services', 'ec2'], put_cidr_name, callback_args)
 
 #
 # List the resources associated with a given VPC security group (e.g. ec2 instances, redshift clusters, ...)
@@ -53,3 +57,34 @@ def list_resources_in_security_group(aws_config, current_config, path, current_p
         manage_dictionary(sg['used_by'][service]['resource_type'][resource_type], resource_status, [])
         if not resource_id in sg['used_by'][service]['resource_type'][resource_type][resource_status]:
             sg['used_by'][service]['resource_type'][resource_type][resource_status].append(resource_id)
+
+#
+# Add a display name for all known CIDRs
+#
+known_cidrs = {'0.0.0.0/0': 'All'}
+def put_cidr_name(aws_config, current_config, path, current_path, resource_id, callback_args):
+    if 'cidrs' in current_config:
+        cidr_list = []
+        for cidr in current_config['cidrs']:
+            if type(cidr) == dict:
+                cidr = cidr['CIDR']
+            if cidr in known_cidrs:
+                cidr_name = known_cidrs[cidr]
+            else:
+                cidr_name = get_cidr_name(cidr, callback_args['ip_ranges'], callback_args['ip_ranges_name_key'][0])
+                known_cidrs[cidr] = cidr_name
+            cidr_list.append({'CIDR': cidr, 'CIDRName': cidr_name})
+        current_config['cidrs'] = cidr_list
+
+#
+# Read display name for CIDRs from ip-ranges files
+#
+def get_cidr_name(cidr, ip_ranges_files, ip_ranges_name_key):
+    for filename in ip_ranges_files:
+        ip_ranges = read_ip_ranges(filename, local_file = True)
+        for ip_range in ip_ranges:
+            ip_prefix = netaddr.IPNetwork(ip_range['ip_prefix'])
+            cidr = netaddr.IPNetwork(cidr)
+            if cidr in ip_prefix:
+                return ip_range[ip_ranges_name_key]
+    return 'Unknown CIDR'

--- a/Recurse.py
+++ b/Recurse.py
@@ -64,7 +64,7 @@ def get_value_at(all_info, current_path, key):
             target_path = current_path
         elif '.' in key:
             target_path = current_path[0:len(keys)-1]
-            if keys[-1] != 'id':
+            if keys[-1] != 'id' and keys[-1] != '':
                 target_path.append(keys[-1])
         else:
             target_path = copy.deepcopy(current_path)

--- a/Scout2.py
+++ b/Scout2.py
@@ -121,7 +121,7 @@ def main(args):
         manage_dictionary(aws_config, 'account_id', None)
 
     ##### VPC analyzis
-    analyze_vpc_config(aws_config, args.ip_ranges, args.ip_ranges_name_key)
+    analyze_vpc_config(aws_config, args.ip_ranges, args.ip_ranges_key_name)
 
     ##### Single service analyzis
     for service in services:

--- a/Scout2.py
+++ b/Scout2.py
@@ -121,7 +121,7 @@ def main(args):
         manage_dictionary(aws_config, 'account_id', None)
 
     ##### VPC analyzis
-    analyze_vpc_config(aws_config)
+    analyze_vpc_config(aws_config, args.ip_ranges, args.ip_ranges_name_key)
 
     ##### Single service analyzis
     for service in services:
@@ -162,6 +162,8 @@ add_sts_argument(parser, 'mfa-code')
 add_common_argument(parser, default_args, 'regions')
 add_common_argument(parser, default_args, 'with-gov')
 add_common_argument(parser, default_args, 'with-cn')
+add_common_argument(parser, default_args, 'ip-ranges')
+add_common_argument(parser, default_args, 'ip-ranges-key-name')
 add_iam_argument(parser, default_args, 'csv-credentials')
 add_s3_argument(parser, default_args, 'bucket-name')
 add_s3_argument(parser, default_args, 'skipped-bucket-name')

--- a/report.html
+++ b/report.html
@@ -1291,11 +1291,11 @@
                 <li class="dropdown-header">CloudTrail config</li>
                 <li id="cloudtrail_load_button"><a href="javascript:load_config('cloudtrail')">Load</a></li>
                 <script id="cloudtrail_violation-list-template" type="text/x-handlebars-template">
-                  <li class="dropdown-header">CloudTrail config</li>
-                  <li><a href="javascript:list_generic('cloudtrail_region')">Trails</a></li>
-                  <li class="divider"></li>
                   <li class="dropdown-header">Summaries</li>
                   <li><a href="javascript:list_generic('cloudtrail_dashboard')">Dashboard</a></li>
+                  <li class="divider"></li>
+                  <li class="dropdown-header">CloudTrail config</li>
+                  <li><a href="javascript:list_generic('cloudtrail_region')">Trails</a></li>
                   <li class="divider"></li>
                   <li class="dropdown-header">Security risks</li>
                   {{#each items}}
@@ -1310,16 +1310,16 @@
                 <li class="dropdown-header">EC2 config</li>
                 <li id="ec2_load_button"><a href="javascript:load_config('ec2')">Load</a></li>
                 <script id="ec2_violation-list-template" type="text/x-handlebars-template">
+                  <li class="dropdown-header">Summaries</li>
+                  <li><a href="javascript:list_generic('ec2_dashboard')">Dashboard</a></li>
+                  <li><a href="javascript:list_generic('ec2_attack_surface')">External Attack Surface</a></li>
+                  <li class="divider"></li>
                   <li class="dropdown-header">EC2 config</li>
                   <li><a href="javascript:list_generic('ec2_elb')">ELBs</a></li>
                   <li><a href="javascript:list_generic('ec2_instance')">Instances</a></li>
                   <li><a href="javascript:list_generic('ec2_vpc')">VPCs</a></li>
                   <li><a href="javascript:list_generic('ec2_network_acl')">Network ACLs</a></li>
                   <li><a href="javascript:list_generic('ec2_security_group')">Security Groups</a></li>
-                  <li class="divider"></li>
-                  <li class="dropdown-header">Summaries</li>
-                  <li><a href="javascript:list_generic('ec2_dashboard')">Dashboard</a></li>
-                  <li><a href="javascript:list_generic('ec2_attack_surface')">External Attack Surface</a></li>
                   <li class="divider"></li>
                   <li class="dropdown-header">Security risks</li>
                   {{#each items}}
@@ -1334,16 +1334,16 @@
                 <li class="dropdown-header">IAM config</li>
                 <li id="iam_load_button"><a href="javascript:load_config('iam')">Load</a></li>
                 <script id="iam_violation-list-template" type="text/x-handlebars-template">
+                  <li class="dropdown-header">Summaries</li>
+                  <li><a href="javascript:list_generic('iam_dashboard')">Dashboard</a></li>
+                  <li><a href="javascript:list_generic('iam_Permission')">Permissions</a></li>
+                  <li class="divider"></li>
                   <li class="dropdown-header">IAM config</li>
                   <li><a href="javascript:list_generic('iam_Group')">Groups</a></li>
                   <li><a href="javascript:list_generic('iam_PasswordPolicy')">Password policy</a></li>
                   <li><a href="javascript:list_generic('iam_Role')">Roles</a></li>
                   <li><a href="javascript:list_generic('iam_CredentialReport')">Root account</a></li>
                   <li><a href="javascript:list_generic('iam_User')">Users</a></li>
-                  <li class="divider"></li>
-                  <li class="dropdown-header">Summaries</li>
-                  <li><a href="javascript:list_generic('iam_dashboard')">Dashboard</a></li>
-                  <li><a href="javascript:list_generic('iam_Permission')">Permissions</a></li>
                   <li class="divider"></li>
                   <li class="dropdown-header">Security risks</li>
                   {{#each items}}
@@ -1358,12 +1358,12 @@
                 <li class="dropdown-header">RDS config</li>
                 <li id="rds_load_button"><a href="javascript:load_config('rds')">Load</a></li>
                 <script id="rds_violation-list-template" type="text/x-handlebars-template">
+                  <li class="dropdown-header">Summaries</li>
+                  <li><a href="javascript:list_generic('rds_dashboard')">Dashboard</a></li>
+                  <li class="divider"></li>
                   <li class="dropdown-header">RDS config</li>
                   <li><a href="javascript:list_generic('rds_instance')">Instances</a></li>
                   <li><a href="javascript:list_generic('rds_security_group')">Security Groups</a></li>
-                  <li class="divider"></li>
-                  <li class="dropdown-header">Summaries</li>
-                  <li><a href="javascript:list_generic('rds_dashboard')">Dashboard</a></li>
                   <li class="divider"></li>
                   <li class="dropdown-header">Security risks</li>
                   {{#each items}}
@@ -1379,13 +1379,13 @@
                 <li class="dropdown-header">Redshift config</li>
                 <li><a href="javascript:load_config('redshift')">Load</a></li>
                 <script id="redshift_violation-list-template" type="text/x-handlebars-template">
+                  <li class="dropdown-header">Summaries</li>
+                  <li><a href="javascript:list_generic('redshift_dashboard')">Dashboard</a></li>
+                  <li class="divider"></li>
                   <li class="dropdown-header">Redshift config</li>
                   <li><a href="javascript:list_generic('redshift_cluster')">Clusters</a></li>
                   <li><a href="javascript:list_generic('redshift_parameter_group')">Parameter Groups</a></li>
                   <li><a href="javascript:list_generic('redshift_security_group')">Security Groups</a></li>
-                  <li class="divider"></li>
-                  <li class="dropdown-header">Summaries</li>
-                  <li><a href="javascript:list_generic('redshift_dashboard')">Dashboard</a></li>
                   <li class="divider"></li>
                   <li class="dropdown-header">Security risks</li>
                   {{#each items}}
@@ -1400,11 +1400,11 @@
                 <li class="dropdown-header">S3 config</li>
                 <li><a href="javascript:load_config('s3')">Load</a></li>
                 <script id="s3_violation-list-template" type="text/x-handlebars-template">
-                  <li class="dropdown-header">S3 config</li>
-                  <li><a href="javascript:list_generic('s3_bucket')">Buckets</a></li>
-                  <li class="divider"></li>
                   <li class="dropdown-header">Summaries</li>
                   <li><a href="javascript:list_generic('s3_dashboard')">Dashboard</a></li>
+                  <li class="divider"></li>
+                  <li class="dropdown-header">S3 config</li>
+                  <li><a href="javascript:list_generic('s3_bucket')">Buckets</a></li>
                   <li class="divider"></li>
                   <li class="dropdown-header">Security risks</li>
                   {{#each items}}

--- a/report.html
+++ b/report.html
@@ -218,11 +218,11 @@
     <script id="ip_grants-partial" type="text/x-handlebars-template">
       <ul>
         {{#each items}}
-          <span id="ec2_security_groups-{{../protocol}}-{{../ports}}-{{this}}-{{../sg_id}}">
+          <span id="ec2_security_groups-{{../protocol}}-{{../ports}}-{{CIDR}}-{{../sg_id}}">
           <span id="ec2_security_groups-ports-range-{{../sg_id}}-{{../ports}}">
           <span id="ec2_security_groups-all-ports-open-to-self-{{../sg_id}}">
           <span class="ec2_attack_surface_item">
-            <li class="list-group-item-text">{{this}}</li>
+            <li class="list-group-item-text">{{CIDR}} {{#if CIDRName}}({{CIDRName}}){{/if}}</li>
           </span></span></span>
         {{/each}}
       </ul>

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ boto3>=1.1.0
 requests>=2.4.0
 python-dateutil>=2.2
 netaddr>=0.7.11
-opinel>=0.19.3,<0.20.0
+opinel>=0.19.6,<0.20.0


### PR DESCRIPTION
When provided with one or multiple ip-ranges files, the Scout2 report will display a friendly name for known CIDRs, to enable better review of security group rules.