### PR TITLE
Travis CI: Add Python 3.7 and flake8 to the testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: python
 
+# use container-base infrastructure
+sudo: false
+
 python:
   - "2.7"
   - "3.3"
@@ -7,9 +10,21 @@ python:
   - "3.5"
   - "3.6"
 
-before_script:
+matrix:
+  include:
+    - python: "3.7"
+      dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
+      sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
+
+install:
   - pip install -r requirements.txt
-  - pip install coveralls
+  - pip install coveralls flake8
+
+before_script:
+  # stop the build if there are Python syntax errors or undefined names
+  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
 # command to run tests
 script:
@@ -21,9 +36,6 @@ script:
     - nosetests --with-coverage tests/test-rules-ruleset.py
     - nosetests --with-coverage tests/test-rules-processingengine.py
     - nosetests --with-coverage --nocapture tests/test-scout2.py
-
-# use container-base infrastructure
-sudo: false
 
 # Update test coverage -- only when run locally
 #after_success:

--- a/AWSScout2/services/ec2.py
+++ b/AWSScout2/services/ec2.py
@@ -3,6 +3,8 @@
 EC2-related classes and functions
 """
 
+import netaddr
+
 # TODO: move a lot of this to VPCconfig, and use some sort of filter to only list SGs in EC2 classic
 
 from opinel.utils.aws import get_name

--- a/AWSScout2/services/vpc.py
+++ b/AWSScout2/services/vpc.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+import copy
 import netaddr
 
 from opinel.utils.aws import get_name


### PR DESCRIPTION
Add [flake8](http://flake8.pycqa.org) tests to find Python syntax errors and undefined names.

__E901,E999,F821,F822,F823__ are the "_showstopper_" flake8 issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree